### PR TITLE
Add outline to macos style buttons

### DIFF
--- a/breezebutton.cpp
+++ b/breezebutton.cpp
@@ -209,6 +209,14 @@ namespace Breeze
             inactiveCol = QColor(gray, gray, gray);
         }
 
+        QColor outlineCol(Qt::gray);
+        if (qGray(d->titleBarColor().rgb()) > 127)
+            outlineCol = QColor(0, 0, 0, 45);
+        else
+            outlineCol = QColor(0, 0, 0, 255 - 2 * qGray(d->titleBarColor().rgb()));
+            // outlineCol = QColor(255, 255, 255, 127);
+    
+
         // render mark
         const QColor foregroundColor( this->foregroundColor(inactiveCol) );
         if( foregroundColor.isValid() )
@@ -219,6 +227,11 @@ namespace Breeze
             pen.setCapStyle( Qt::RoundCap );
             pen.setJoinStyle( Qt::MiterJoin );
             pen.setWidthF( PenWidth::Symbol*qMax((qreal)1.0, 20/width ) );
+
+            QPen outline_pen( outlineCol );
+            outline_pen.setCapStyle( Qt::RoundCap );
+            outline_pen.setJoinStyle( Qt::MiterJoin );
+            outline_pen.setWidthF( 1.0 );
 
             switch( type() )
             {
@@ -243,7 +256,12 @@ namespace Breeze
                         }
                         painter->setBrush( QBrush(grad) );
                         painter->setPen( Qt::NoPen );
-                        painter->drawEllipse( QRectF( 2, 2, 14, 14 ) );
+                        painter->drawEllipse( QRectF( 2, 2, 14, 14 )  );
+
+                        painter->setPen( outline_pen );
+                        painter->setBrush( Qt::NoBrush );
+                        painter->drawEllipse( QRectF( 2, 2, 14, 14 )  );
+
                         if( backgroundColor.isValid() )
                         {
                             painter->setPen( Qt::NoPen );
@@ -253,7 +271,13 @@ namespace Breeze
                                          : static_cast<qreal>(2) * m_animation->currentValue().toReal());
                             QPointF c(static_cast<qreal>(9), static_cast<qreal>(9));
                             painter->drawEllipse( c, r, r );
+
+                            painter->setPen( outline_pen );
+                            painter->setBrush( Qt::NoBrush );
+                            painter->drawEllipse( c, r, r  );
                         }
+
+
                     }
                     else {
                         if( backgroundColor.isValid() )
@@ -300,6 +324,11 @@ namespace Breeze
                         painter->setBrush( QBrush(grad) );
                         painter->setPen( Qt::NoPen );
                         painter->drawEllipse( QRectF( 2, 2, 14, 14 ) );
+
+                        painter->setPen( outline_pen );
+                        painter->setBrush( Qt::NoBrush );
+                        painter->drawEllipse( QRectF( 2, 2, 14, 14 )  );
+
                         if( backgroundColor.isValid() )
                         {
                             painter->setPen( Qt::NoPen );
@@ -309,6 +338,10 @@ namespace Breeze
                                          : static_cast<qreal>(2) * m_animation->currentValue().toReal());
                             QPointF c(static_cast<qreal>(9), static_cast<qreal>(9));
                             painter->drawEllipse( c, r, r );
+
+                            painter->setPen( outline_pen );
+                            painter->setBrush( Qt::NoBrush );
+                            painter->drawEllipse( c, r, r  );
                         }
                     }
                     else {
@@ -360,6 +393,11 @@ namespace Breeze
                         painter->setBrush( QBrush(grad) );
                         painter->setPen( Qt::NoPen );
                         painter->drawEllipse( QRectF( 2, 2, 14, 14 ) );
+
+                        painter->setPen( outline_pen );
+                        painter->setBrush( Qt::NoBrush );
+                        painter->drawEllipse( QRectF( 2, 2, 14, 14 )  );
+
                         if( backgroundColor.isValid() )
                         {
                             painter->setPen( Qt::NoPen );
@@ -369,6 +407,10 @@ namespace Breeze
                                          : static_cast<qreal>(2) * m_animation->currentValue().toReal());
                             QPointF c(static_cast<qreal>(9), static_cast<qreal>(9));
                             painter->drawEllipse( c, r, r );
+
+                            painter->setPen( outline_pen );
+                            painter->setBrush( Qt::NoBrush );
+                            painter->drawEllipse( c, r, r  );
                         }
                     }
                     else {
@@ -417,6 +459,11 @@ namespace Breeze
                             painter->drawEllipse( QRectF( 0, 0, 18, 18 ) );
                         else {
                             painter->drawEllipse( QRectF( 2, 2, 14, 14 ) );
+
+                            painter->setPen( outline_pen );
+                            painter->setBrush( Qt::NoBrush );
+                            painter->drawEllipse( QRectF( 2, 2, 14, 14 )  );
+
                             if( backgroundColor.isValid() )
                             {
                                 painter->setPen( Qt::NoPen );
@@ -425,6 +472,10 @@ namespace Breeze
                                           + static_cast<qreal>(2) * m_animation->currentValue().toReal();
                                 QPointF c(static_cast<qreal>(9), static_cast<qreal>(9));
                                 painter->drawEllipse( c, r, r );
+
+                                painter->setPen( outline_pen );
+                                painter->setBrush( Qt::NoBrush );
+                                painter->drawEllipse( c, r, r  );
                             }
                         }
                     }
@@ -497,6 +548,11 @@ namespace Breeze
                             painter->drawEllipse( QRectF( 0, 0, 18, 18 ) );
                         else {
                             painter->drawEllipse( QRectF( 2, 2, 14, 14 ) );
+
+                            painter->setPen( outline_pen );
+                            painter->setBrush( Qt::NoBrush );
+                            painter->drawEllipse( QRectF( 2, 2, 14, 14 )  );
+
                             if( backgroundColor.isValid() )
                             {
                                 painter->setPen( Qt::NoPen );
@@ -505,6 +561,10 @@ namespace Breeze
                                           + static_cast<qreal>(2) * m_animation->currentValue().toReal();
                                 QPointF c(static_cast<qreal>(9), static_cast<qreal>(9));
                                 painter->drawEllipse( c, r, r );
+
+                                painter->setPen( outline_pen );
+                                painter->setBrush( Qt::NoBrush );
+                                painter->drawEllipse( c, r, r  );
                             }
                         }
                     }
@@ -562,6 +622,11 @@ namespace Breeze
                             painter->drawEllipse( QRectF( 0, 0, 18, 18 ) );
                         else {
                             painter->drawEllipse( QRectF( 2, 2, 14, 14 ) );
+
+                            painter->setPen( outline_pen );
+                            painter->setBrush( Qt::NoBrush );
+                            painter->drawEllipse( QRectF( 2, 2, 14, 14 )  );
+
                             if( backgroundColor.isValid() )
                             {
                                 painter->setPen( Qt::NoPen );
@@ -570,6 +635,10 @@ namespace Breeze
                                           + static_cast<qreal>(2) * m_animation->currentValue().toReal();
                                 QPointF c(static_cast<qreal>(9), static_cast<qreal>(9));
                                 painter->drawEllipse( c, r, r );
+
+                                painter->setPen( outline_pen );
+                                painter->setBrush( Qt::NoBrush );
+                                painter->drawEllipse( c, r, r  );
                             }
                         }
                     }
@@ -635,6 +704,11 @@ namespace Breeze
                             painter->drawEllipse( QRectF( 0, 0, 18, 18 ) );
                         else {
                             painter->drawEllipse( QRectF( 2, 2, 14, 14 ) );
+
+                            painter->setPen( outline_pen );
+                            painter->setBrush( Qt::NoBrush );
+                            painter->drawEllipse( QRectF( 2, 2, 14, 14 )  );
+
                             if( backgroundColor.isValid() )
                             {
                                 painter->setPen( Qt::NoPen );
@@ -643,6 +717,10 @@ namespace Breeze
                                           + static_cast<qreal>(2) * m_animation->currentValue().toReal();
                                 QPointF c(static_cast<qreal>(9), static_cast<qreal>(9));
                                 painter->drawEllipse( c, r, r );
+
+                                painter->setPen( outline_pen );
+                                painter->setBrush( Qt::NoBrush );
+                                painter->drawEllipse( c, r, r  );
                             }
                         }
                     }
@@ -705,6 +783,11 @@ namespace Breeze
                         painter->setBrush( QBrush(grad) );
                         painter->setPen( Qt::NoPen );
                         painter->drawEllipse( QRectF( 2, 2, 14, 14 ) );
+
+                        painter->setPen( outline_pen );
+                        painter->setBrush( Qt::NoBrush );
+                        painter->drawEllipse( QRectF( 2, 2, 14, 14 )  );
+
                         if( backgroundColor.isValid() )
                         {
                             painter->setPen( Qt::NoPen );
@@ -713,6 +796,10 @@ namespace Breeze
                                       + static_cast<qreal>(2) * m_animation->currentValue().toReal();
                             QPointF c(static_cast<qreal>(9), static_cast<qreal>(9));
                             painter->drawEllipse( c, r, r );
+
+                            painter->setPen( outline_pen );
+                            painter->setBrush( Qt::NoBrush );
+                            painter->drawEllipse( c, r, r  );
                         }
                     }
                     if (!macOSBtn || isPressed() || isHovered()) {
@@ -761,6 +848,11 @@ namespace Breeze
                         painter->setBrush( QBrush(grad) );
                         painter->setPen( Qt::NoPen );
                         painter->drawEllipse( QRectF( 2, 2, 14, 14 ) );
+
+                        painter->setPen( outline_pen );
+                        painter->setBrush( Qt::NoBrush );
+                        painter->drawEllipse( QRectF( 2, 2, 14, 14 )  );
+
                         if( backgroundColor.isValid() )
                         {
                             painter->setPen( Qt::NoPen );
@@ -769,6 +861,10 @@ namespace Breeze
                                       + static_cast<qreal>(2) * m_animation->currentValue().toReal();
                             QPointF c(static_cast<qreal>(9), static_cast<qreal>(9));
                             painter->drawEllipse( c, r, r );
+
+                            painter->setPen( outline_pen );
+                            painter->setBrush( Qt::NoBrush );
+                            painter->drawEllipse( c, r, r  );
                         }
                     }
                     if (!macOSBtn || isPressed() || isHovered()) {


### PR DESCRIPTION
Hi, I really like this window decoration, especially with macos style buttons, but I noticed that compared to a real mac, the colored circles are missing an outline. This pull request adds a slight gray outline to the colored circles. The outline strength is loosely based on the appearance of macos Mojave.

Here, please take a look:

![breeze_enhanced_light](https://user-images.githubusercontent.com/31393177/162724463-4aa9d757-457b-4907-aa43-5fa7295f4049.gif)

The outline is made stronger when the titlebar background color is dark:

![breeze_enhanced_dark](https://user-images.githubusercontent.com/31393177/162724622-dfcb1cf1-9c35-4d79-a29b-b8af55abc0c4.gif)

Here is another example using the color theme "Breeze Classic":

![breeze_enhanced_classic](https://user-images.githubusercontent.com/31393177/162724722-746ccce1-7e73-4481-a20c-41d43e816bc2.gif)

Edit: Note that I'm using LightlyShaders, which applies additional window corner rounding and adds an outline to the window.
