### PR TITLE
Add variables needed for cpack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,13 @@ set(KF6_MIN_VERSION "6.3.0")
 
 find_package(ECM ${KF6_MIN_VERSION} REQUIRED NO_MODULE)
 
+set(CPACK_PACKAGE_NAME "BreezeEnhanced")
+set(CPACK_PACKAGING_INSTALL_PREFIX "/usr")
+set(CPACK_PACKAGE_FILE_NAME "BreezeEnhanced")
+set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Enhanced version of the Breeze Window Decoration for KWIN that pairs well with kvantum themes.")
+include(CPack)
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR} ${CMAKE_SOURCE_DIR}/cmake)


### PR DESCRIPTION
Adding the variables needed for Cpack so that users on Fedora Kinoite can layer the package in their OSTree after compiling in a distrobox

Realized I forgot that pulling from a fork actually does exist. Oops.